### PR TITLE
First part of gradle version catalog

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -88,7 +88,7 @@ dependencies {
 
     implementation(libs.androidx.nav.compose)
 
-    api(libs.atmoicfu)
+    api(libs.atomicfu)
 
     kapt(libs.dagger.compiler)
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,32 +66,31 @@ dependencies {
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
     implementation "androidx.compose.ui:ui:$compose_version"
     implementation "androidx.compose.foundation:foundation:$compose_version"
-    implementation "me.saket.swipe:swipe:1.0.0"
-    implementation 'androidx.activity:activity-compose:1.3.1'
-    implementation 'androidx.compose.material3:material3:1.0.0-alpha11'
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
-    implementation 'com.google.dagger:dagger:2.44.2'
-    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
-    implementation 'de.charlex.compose:revealswipe:1.0.0'
-    implementation 'io.coil-kt:coil-compose:2.2.2'
-    implementation("com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:0.8.0")
-    implementation("com.squareup.okhttp3:logging-interceptor:4.10.0")
-    implementation("com.squareup.okhttp3:okhttp:4.10.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0-RC")
-    implementation "androidx.constraintlayout:constraintlayout-compose:1.0.1"
-    implementation("androidx.browser:browser:1.5.0")
-//    implementation "org.mobilenativefoundation.store:store5:5.0.0-alpha03"
-    implementation 'org.mobilenativefoundation.store:cache5-jvm:5.0.0-alpha03'
-    implementation 'org.mobilenativefoundation.store:store5-jvm:5.0.0-alpha03'
-    implementation 'androidx.paging:paging-compose:1.0.0-alpha18'
-    implementation 'dev.marcellogalhardo:retained-compose:1.0.0'
+    implementation(libs.me.saket.swipe)
+    implementation(libs.androidx.activity.activity.compose)
+    implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.core.core.ktx)
+    implementation(libs.androidx.lifecycle.lifecycle.runtime.ktx)
+    implementation(libs.com.google.dagger)
+    implementation(libs.com.squareup.retrofit2.retrofit)
+    implementation(libs.de.charlex.compose.revealswipe)
+    implementation(libs.coil.compose)
+    implementation(libs.com.jakewharton.retrofit)
+    implementation(libs.com.squareup.okhttp3.logging.interceptor)
+    implementation(libs.com.squareup.okhttp3.okhttp)
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.androidx.constraintlayout)
+    implementation(libs.androidx.browser)
+    implementation(libs.store.cache)
+    implementation(libs.store.jvm)
+    implementation(libs.androidx.paging.compose)
+    implementation(libs.retained.compose)
 
-    implementation "androidx.navigation:navigation-compose:2.5.3"
+    implementation(libs.androidx.nav.compose)
 
-    api "org.jetbrains.kotlinx:atomicfu:0.18.5"
+    api(libs.atmoicfu)
 
-    kapt 'com.google.dagger:dagger-compiler:2.44.2'
+    kapt(libs.dagger.compiler)
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4"
     testImplementation 'junit:junit:4.13.2'
     testImplementation("org.assertj:assertj-core:3.24.2")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,7 +37,7 @@ androidx-core-core-ktx = { module = "androidx.core:core-ktx", version.ref = "and
 androidx-lifecycle-lifecycle-runtime-ktx = "androidx.lifecycle:lifecycle-runtime-ktx:2.3.1"
 androidx-nav-compose = { module = "androidx.navigation:navigation-compose", version.ref = "androidx-nav-compose" }
 androidx-paging-compose = { module = "androidx.paging:paging-compose", version.ref = "androidx-paging-compose" }
-atmoicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "atomicfu" }
+atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "atomicfu" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "io-coil-kt" }
 com-google-dagger = { module = "com.google.dagger:dagger", version.ref = "com-google-dagger" }
 com-jakewharton-retrofit = { module = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter", version.ref = "jw-converter" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,63 @@
+[versions]
+androidx-activity = "1.3.1"
+androidx-arch-core = "2.1.0"
+androidx-compose-animation = "1.1.1"
+androidx-compose-foundation = "1.2.1"
+androidx-compose-runtime = "1.2.1"
+androidx-core = "1.8.0"
+androidx-nav-compose = "2.5.3"
+androidx-paging-compose = "1.0.0-alpha18"
+androidx-savedstate = "1.2.0"
+androidx-vectordrawable = "1.1.0"
+atomicfu = "0.18.5"
+browser = "1.5.0"
+com-google-dagger = "2.44.2"
+com-squareup-anvil = "2.4.4"
+com-squareup-okhttp3 = "4.10.0"
+com-squareup-okio = "3.2.0"
+constraintlayout-compose = "1.0.1"
+dagger-compiler = "2.44.2"
+jw-converter = "0.8.0"
+kotlinx-serialization-json = "1.5.0-RC"
+io-coil-kt = "2.2.2"
+org-jetbrains-kotlin = "1.8.10"
+material = "1.0.0-alpha11"
+retained-compose = "1.0.0"
+retrofit = "2.9.0"
+revealswipe = "1.0.0"
+store = "5.0.0-alpha03"
+swipe = "1.0.0"
+
+[libraries]
+androidx-activity-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
+androidx-browser = { module = "androidx.browser:browser", version.ref = "browser" }
+androidx-compose-material3 = { module = "androidx.compose.material3:material3", version.ref = "material" }
+androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout-compose", version.ref = "constraintlayout-compose" }
+androidx-core-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
+androidx-lifecycle-lifecycle-runtime-ktx = "androidx.lifecycle:lifecycle-runtime-ktx:2.3.1"
+androidx-nav-compose = { module = "androidx.navigation:navigation-compose", version.ref = "androidx-nav-compose" }
+androidx-paging-compose = { module = "androidx.paging:paging-compose", version.ref = "androidx-paging-compose" }
+atmoicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "atomicfu" }
+coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "io-coil-kt" }
+com-google-dagger = { module = "com.google.dagger:dagger", version.ref = "com-google-dagger" }
+com-jakewharton-retrofit = { module = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter", version.ref = "jw-converter" }
+com-squareup-okhttp3-logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "com-squareup-okhttp3" }
+com-squareup-okhttp3-okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "com-squareup-okhttp3" }
+com-squareup-retrofit2-retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
+dagger-compiler = { module = "com.google.dagger:dagger-compiler", version.ref = "dagger-compiler" }
+de-charlex-compose-revealswipe = { module = "de.charlex.compose:revealswipe", version.ref = "revealswipe" }
+me-saket-swipe = { module = "me.saket.swipe:swipe", version.ref = "swipe" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
+retained-compose = { module = "dev.marcellogalhardo:retained-compose", version.ref = "retained-compose" }
+store-cache = { module = "org.mobilenativefoundation.store:cache5-jvm", version.ref = "store" }
+store-jvm = { module = "org.mobilenativefoundation.store:store5-jvm", version.ref = "store" }
+
+[plugins]
+com-android-application = "com.android.application:7.4.1"
+com-android-library = "com.android.library:7.4.1"
+com-github-ben-manes-versions = "com.github.ben-manes.versions:0.41.0"
+com-squareup-anvil = "com.squareup.anvil:2.4.4"
+kotlinx-serialization = "kotlinx-serialization:1.8.10"
+nl-littlerobots-version-catalog-update = "nl.littlerobots.version-catalog-update:0.7.0"
+org-jetbrains-kotlin-android = "org.jetbrains.kotlin.android:1.8.10"
+org-jetbrains-kotlin-plugin-serialization = "org.jetbrains.kotlin.plugin.serialization:1.8.10"


### PR DESCRIPTION
gradle version catalogs standardizes how deps are declared and opens the door for lots of update and analysis tools.

https://proandroiddev.com/gradle-version-catalogs-for-an-awesome-dependency-management-f2ba700ff894

gradle version catalogs will be fully supported in AS gopher i believe.

this is a first pass, if merged more will follow to fully convert. -> convert plugin to use alias, use compose bom