### PR TITLE
[Gradle] - Finish version catalog and plugins conversion

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,8 +61,8 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
 
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation(libs.espresso)
+    androidTestImplementation(libs.junit.ext)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
     debugImplementation(libs.androidx.compose.ui.tooling)
     implementation(libs.androidx.compose.ui.tooling.preview)
@@ -94,11 +94,11 @@ dependencies {
     api(libs.atomicfu)
 
     kapt(libs.dagger.compiler)
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4"
-    testImplementation 'junit:junit:4.13.2'
-    testImplementation("org.assertj:assertj-core:3.24.2")
+    testImplementation(libs.coroutines.test)
+    testImplementation(libs.junit)
+    testImplementation(libs.assertj)
 
-    androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4"
-    androidTestImplementation 'junit:junit:4.13.2'
-    androidTestImplementation("org.assertj:assertj-core:3.24.2")
+    androidTestImplementation(libs.coroutines.test)
+    androidTestImplementation(libs.junit)
+    androidTestImplementation(libs.assertj)
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -58,6 +58,8 @@ android {
 }
 
 dependencies {
+    implementation(platform(libs.androidx.compose.bom))
+
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,14 +60,14 @@ android {
 dependencies {
     implementation(platform(libs.androidx.compose.bom))
 
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
+    androidTestImplementation(libs.androidx.compose.ui.test.junit4)
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_version"
-    debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
-    implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
-    implementation "androidx.compose.ui:ui:$compose_version"
-    implementation "androidx.compose.foundation:foundation:$compose_version"
+    debugImplementation(libs.androidx.compose.ui.test.manifest)
+    debugImplementation(libs.androidx.compose.ui.tooling)
+    implementation(libs.androidx.compose.ui.tooling.preview)
+    implementation(libs.androidx.compose.ui)
+    implementation(libs.androidx.compose.foundation)
     implementation(libs.me.saket.swipe)
     implementation(libs.androidx.activity.activity.compose)
     implementation(libs.androidx.compose.material3)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,9 +1,9 @@
 plugins {
-    id 'com.android.application'
-    id 'org.jetbrains.kotlin.android'
-    id "org.jetbrains.kotlin.plugin.serialization" version "1.8.10"
-    id 'com.squareup.anvil' version "2.4.4"
-    id 'kotlin-kapt'
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.anvil)
+    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 android {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,7 +48,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.4.2'
+        kotlinCompilerExtensionVersion = libs.versions.androidxComposeCompiler.get()
     }
     packagingOptions {
         resources {
@@ -59,10 +59,8 @@ android {
 
 dependencies {
     implementation(platform(libs.androidx.compose.bom))
+    kapt(libs.dagger.compiler)
 
-    androidTestImplementation(libs.androidx.compose.ui.test.junit4)
-    androidTestImplementation(libs.espresso)
-    androidTestImplementation(libs.junit.ext)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
     debugImplementation(libs.androidx.compose.ui.tooling)
     implementation(libs.androidx.compose.ui.tooling.preview)
@@ -88,12 +86,9 @@ dependencies {
     implementation(libs.store.jvm)
     implementation(libs.androidx.paging.compose)
     implementation(libs.retained.compose)
-
     implementation(libs.androidx.nav.compose)
-
     api(libs.atomicfu)
 
-    kapt(libs.dagger.compiler)
     testImplementation(libs.coroutines.test)
     testImplementation(libs.junit)
     testImplementation(libs.assertj)
@@ -101,4 +96,7 @@ dependencies {
     androidTestImplementation(libs.coroutines.test)
     androidTestImplementation(libs.junit)
     androidTestImplementation(libs.assertj)
+    androidTestImplementation(libs.androidx.compose.ui.test.junit4)
+    androidTestImplementation(libs.espresso)
+    androidTestImplementation(libs.junit.ext)
 }

--- a/app/src/main/java/com/androiddev/social/timeline/ui/NotifIcon.kt
+++ b/app/src/main/java/com/androiddev/social/timeline/ui/NotifIcon.kt
@@ -40,6 +40,7 @@ fun NotifIcon() {
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @ExperimentalAnimationApi
 @ExperimentalComposeUiApi
 @Composable

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,8 @@
 plugins {
-    id 'com.android.application' version '7.4.1' apply false
-    id 'com.android.library' version '7.4.1' apply false
-    id 'org.jetbrains.kotlin.android' version '1.8.10' apply false
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.anvil) apply false
+    alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.kotlin.kapt) apply false
+    alias(libs.plugins.kotlin.serialization) apply false
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,3 @@
-buildscript {
-    ext {
-        compose_version = '1.3.1'
-    }
-}// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id 'com.android.application' version '7.4.1' apply false
     id 'com.android.library' version '7.4.1' apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ androidx-datastore = "1.0.0"
 androidx-savedstate = "1.2.0"
 androidx-vectordrawable = "1.1.0"
 anvil = "2.4.4"
+assertj = "3.24.2"
 atomicfu = "0.18.5"
 browser = "1.5.0"
 com-google-dagger = "2.44.2"
@@ -19,11 +20,15 @@ com-squareup-anvil = "2.4.4"
 com-squareup-okhttp3 = "4.10.0"
 com-squareup-okio = "3.2.0"
 constraintlayout-compose = "1.0.1"
+coroutines-test = "1.6.4"
 dagger-compiler = "2.44.2"
+espresso = "3.4.0"
 gradle-plugin = "7.4.1"
 jw-converter = "0.8.0"
 kotlinx-serialization-json = "1.5.0-RC"
 kotlin = "1.8.10"
+junit4 = "4.13.2"
+junit-ext = "1.1.3"
 lifecycle-runtime-ktx = "2.3.1"
 io-coil-kt = "2.2.2"
 retained-compose = "1.0.0"
@@ -49,6 +54,7 @@ androidx-lifecycle-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecy
 androidx-nav-compose = { module = "androidx.navigation:navigation-compose", version.ref = "androidx-nav-compose" }
 androidx-paging-compose = { module = "androidx.paging:paging-compose", version.ref = "androidx-paging-compose" }
 androidx-datastore = { module = "androidx.datastore:datastore-preferences", version.ref = "androidx-datastore" }
+assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "atomicfu" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "io-coil-kt" }
 com-google-dagger = { module = "com.google.dagger:dagger", version.ref = "com-google-dagger" }
@@ -56,9 +62,13 @@ com-jakewharton-retrofit = { module = "com.jakewharton.retrofit:retrofit2-kotlin
 com-squareup-okhttp3-logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "com-squareup-okhttp3" }
 com-squareup-okhttp3-okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "com-squareup-okhttp3" }
 com-squareup-retrofit2-retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
+coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines-test"}
 dagger-compiler = { module = "com.google.dagger:dagger-compiler", version.ref = "dagger-compiler" }
 de-charlex-compose-revealswipe = { module = "de.charlex.compose:revealswipe", version.ref = "revealswipe" }
+espresso = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
 me-saket-swipe = { module = "me.saket.swipe:swipe", version.ref = "swipe" }
+junit = { module = "junit:junit", version.ref = "junit4" }
+junit-ext = { module = "androidx.test.ext:junit", version.ref = "junit-ext" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 retained-compose = { module = "dev.marcellogalhardo:retained-compose", version.ref = "retained-compose" }
 store-cache = { module = "org.mobilenativefoundation.store:cache5-jvm", version.ref = "store" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 androidx-activity = "1.3.1"
 androidx-arch-core = "2.1.0"
+androidxComposeBom = "2023.01.00"
 androidx-compose-animation = "1.1.1"
 androidx-compose-foundation = "1.2.1"
 androidx-compose-runtime = "1.2.1"
@@ -20,9 +21,9 @@ constraintlayout-compose = "1.0.1"
 dagger-compiler = "2.44.2"
 jw-converter = "0.8.0"
 kotlinx-serialization-json = "1.5.0-RC"
+lifecycle-runtime-ktx = "2.3.1"
 io-coil-kt = "2.2.2"
 org-jetbrains-kotlin = "1.8.10"
-material = "1.0.0-alpha11"
 retained-compose = "1.0.0"
 retrofit = "2.9.0"
 revealswipe = "1.0.0"
@@ -32,10 +33,11 @@ swipe = "1.0.0"
 [libraries]
 androidx-activity-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-browser = { module = "androidx.browser:browser", version.ref = "browser" }
-androidx-compose-material3 = { module = "androidx.compose.material3:material3", version.ref = "material" }
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidxComposeBom" }
+androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout-compose", version.ref = "constraintlayout-compose" }
 androidx-core-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
-androidx-lifecycle-lifecycle-runtime-ktx = "androidx.lifecycle:lifecycle-runtime-ktx:2.3.1"
+androidx-lifecycle-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle-runtime-ktx" }
 androidx-nav-compose = { module = "androidx.navigation:navigation-compose", version.ref = "androidx-nav-compose" }
 androidx-paging-compose = { module = "androidx.paging:paging-compose", version.ref = "androidx-paging-compose" }
 androidx-datastore = { module = "androidx.datastore:datastore-preferences", version.ref = "androidx-datastore" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ androidx-paging-compose = "1.0.0-alpha18"
 androidx-datastore = "1.0.0"
 androidx-savedstate = "1.2.0"
 androidx-vectordrawable = "1.1.0"
+anvil = "2.4.4"
 atomicfu = "0.18.5"
 browser = "1.5.0"
 com-google-dagger = "2.44.2"
@@ -19,6 +20,7 @@ com-squareup-okhttp3 = "4.10.0"
 com-squareup-okio = "3.2.0"
 constraintlayout-compose = "1.0.1"
 dagger-compiler = "2.44.2"
+gradle-plugin = "7.4.1"
 jw-converter = "0.8.0"
 kotlinx-serialization-json = "1.5.0-RC"
 kotlin = "1.8.10"
@@ -63,11 +65,9 @@ store-cache = { module = "org.mobilenativefoundation.store:cache5-jvm", version.
 store-jvm = { module = "org.mobilenativefoundation.store:store5-jvm", version.ref = "store" }
 
 [plugins]
-com-android-application = "com.android.application:7.4.1"
-com-android-library = "com.android.library:7.4.1"
-com-github-ben-manes-versions = "com.github.ben-manes.versions:0.41.0"
-com-squareup-anvil = "com.squareup.anvil:2.4.4"
-kotlinx-serialization = "kotlinx-serialization:1.8.10"
-nl-littlerobots-version-catalog-update = "nl.littlerobots.version-catalog-update:0.7.0"
-org-jetbrains-kotlin-android = "org.jetbrains.kotlin.android:1.8.10"
-org-jetbrains-kotlin-plugin-serialization = "org.jetbrains.kotlin.plugin.serialization:1.8.10"
+android-application = { id = "com.android.application", version.ref = "gradle-plugin" }
+android-library = { id = "com.android.library", version.ref = "gradle-plugin" }
+anvil = { id = "com.squareup.anvil", version.ref = "anvil" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 androidx-activity = "1.3.1"
 androidx-arch-core = "2.1.0"
 androidxComposeBom = "2023.01.00"
+androidxComposeCompiler = "1.4.2"
 androidx-compose-animation = "1.1.1"
 androidx-compose-foundation = "1.2.1"
 androidx-compose-runtime = "1.2.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,9 +21,9 @@ constraintlayout-compose = "1.0.1"
 dagger-compiler = "2.44.2"
 jw-converter = "0.8.0"
 kotlinx-serialization-json = "1.5.0-RC"
+kotlin = "1.8.10"
 lifecycle-runtime-ktx = "2.3.1"
 io-coil-kt = "2.2.2"
-org-jetbrains-kotlin = "1.8.10"
 retained-compose = "1.0.0"
 retrofit = "2.9.0"
 revealswipe = "1.0.0"
@@ -34,6 +34,12 @@ swipe = "1.0.0"
 androidx-activity-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-browser = { module = "androidx.browser:browser", version.ref = "browser" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidxComposeBom" }
+androidx-compose-ui = { module = "androidx.compose.ui:ui" }
+androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
+androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
+androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
+androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
+androidx-compose-foundation = { module = "androidx.compose.foundation:foundation" }
 androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout-compose", version.ref = "constraintlayout-compose" }
 androidx-core-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }


### PR DESCRIPTION
This change contains the second part of the conversion to version catalogs and the more modern plugins block. I also converted compose usage to a bill-of-materials [bom](https://developer.android.com/jetpack/compose/bom/bom) and going forward when you include a `androidx.compose` dependency you won't need to specify the version since it will be be picked up in the bom. 

All external lib deps are now specified in the toml file, i.e.; kotiln, android gradle plugin, compose bom, compose compiler, anvil plugin, etc. 