### PR TITLE
fix search bar color

### DIFF
--- a/app/src/main/java/com/androiddev/social/search/SearchPresenter.kt
+++ b/app/src/main/java/com/androiddev/social/search/SearchPresenter.kt
@@ -120,7 +120,6 @@ class RealSearchPresenter @Inject constructor(
                     }
 
                     else -> {
-
                         if (results is StoreResponse.Error.Message) {
                             model = SearchModel(error = results.errorMessageOrNull())
                         } else if (results is StoreResponse.Error) {
@@ -140,5 +139,4 @@ class RealSearchPresenter @Inject constructor(
     override fun onQueryTextChange(searchTerm: String) {
         searchInput.tryEmit(searchTerm.lowercase(Locale.getDefault()))
     }
-
 }

--- a/app/src/main/java/com/androiddev/social/search/topbar/SearchBar.kt
+++ b/app/src/main/java/com/androiddev/social/search/topbar/SearchBar.kt
@@ -1,4 +1,4 @@
-package com.slack.exercise.search.topbar
+package com.androiddev.social.search.topbar
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -9,8 +9,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
-import com.androiddev.social.search.topbar.SearchField
 import com.androiddev.social.theme.PaddingSize0_5
+import com.slack.exercise.search.topbar.ClearButton
+import com.slack.exercise.search.topbar.ProgressIndicator
 
 /**
  * Composable used for getting search input from a user

--- a/app/src/main/java/com/androiddev/social/search/topbar/SearchField.kt
+++ b/app/src/main/java/com/androiddev/social/search/topbar/SearchField.kt
@@ -25,10 +25,9 @@ fun RowScope.SearchField(
         focusRequester.requestFocus()
     }
 
-
     BasicTextField(
         value = query,
-        textStyle = MaterialTheme.typography.bodyLarge.copy(color = MaterialTheme.colorScheme.surface),
+        textStyle = MaterialTheme.typography.bodyLarge,
         onValueChange = onQueryChange,
         singleLine = true,
         modifier = Modifier

--- a/app/src/main/java/com/androiddev/social/search/topbar/TopBar.kt
+++ b/app/src/main/java/com/androiddev/social/search/topbar/TopBar.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.slack.exercise.search.SearchState
-import com.slack.exercise.search.topbar.SearchBar
 
 @Composable
 fun TopBar(
@@ -54,7 +53,6 @@ fun TopBar(
         },
         modifier = Modifier.background(Color.White).height(40.dp),
         actions = {
-
         }
     )
 }


### PR DESCRIPTION
This fixes https://github.com/digitalbuddha/Ebony/issues/11. Not sure if I created another bug :D let me know if removing `.copy(color = MaterialTheme.colorScheme.surface)` is safe.